### PR TITLE
Fix package name formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ PhpCodeArcheology is the **first PHP static analysis tool with native MCP (Model
 
 The setup depends on how you installed PhpCodeArcheology:
 
-**Global installation** (`composer global require phpcodearcheology/phpcodearcheology`):
+**Global installation** (`composer global require php-code-archeology/php-code-archeology`):
 
 ```bash
 claude mcp add phpcodearcheology -- phpcodearcheology mcp
 ```
 
-**Project dependency** (`composer require --dev phpcodearcheology/phpcodearcheology`):
+**Project dependency** (`composer require --dev php-code-archeology/php-code-archeology`):
 
 ```bash
 claude mcp add phpcodearcheology -- vendor/bin/phpcodearcheology mcp


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to reflect the correct Composer package name for PhpCodeArcheology. The changes ensure users install the package using the correct vendor and package naming convention.

- Documentation update:
  * Updated both global and project Composer installation commands in `README.md` to use `php-code-archeology/php-code-archeology` instead of the previous `phpcodearcheology/phpcodearcheology` package name.