### PR TITLE
FIX: Correct composer package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ PhpCodeArcheology is the **first PHP static analysis tool with native MCP (Model
 
 The setup depends on how you installed PhpCodeArcheology:
 
-**Global installation** (`composer global require phpcodearcheology/phpcodearcheology`):
+**Global installation** (`composer global require php-code-archeology/php-code-archeology`):
 
 ```bash
 claude mcp add phpcodearcheology -- phpcodearcheology mcp
 ```
 
-**Project dependency** (`composer require --dev phpcodearcheology/phpcodearcheology`):
+**Project dependency** (`composer require --dev php-code-archeology/php-code-archeology`):
 
 ```bash
 claude mcp add phpcodearcheology -- vendor/bin/phpcodearcheology mcp


### PR DESCRIPTION
## Summary
- Fix incorrect package name in MCP setup instructions (`phpcodearcheology/phpcodearcheology` → `php-code-archeology/php-code-archeology`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)