### PR TITLE
Add DocBlock summary display in detail views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DocBlock summary display in HTML report detail views.** Class and method/function detail pages now show the PHPDoc summary text (description before `@`-tags) below the title. Works for all visibility levels including private methods and `__construct`. Empty or missing docblocks are handled gracefully (no empty boxes). Closes #16.
 - **Test coverage for `TooComplexPrediction`.** 42 dedicated unit tests covering all code paths: CC thresholds (small/large code), Difficulty (trivial exit, framework adjustment), Effort and MI (relative-to-average, typed code tolerance, framework tolerance), LCOM (relative-to-average, floor behavior), the full `shouldSkipLcom` exclusion matrix, per-method cognitive complexity, `classTooComplex` flag, File/Function collection handling, and configurable thresholds. All expected values hand-calculated.
 
 ## [2.9.1] - 2026-04-08

--- a/data/metrics/class.php
+++ b/data/metrics/class.php
@@ -473,6 +473,7 @@ return [
         ],
     ],
     ['key' => 'refactoringPriorityDrivers', 'type' => 'storage'],
+    ['key' => 'docBlockSummary', 'type' => 'storage'],
 
     // Test coverage
     [

--- a/data/metrics/file.php
+++ b/data/metrics/file.php
@@ -498,6 +498,7 @@ return [
             \PhpCodeArch\Metrics\MetricCollectionTypeEnum::MethodCollection,
         ],
     ],
+    ['key' => 'docBlockSummary', 'type' => 'storage'],
     [
         'key' => 'parameterCount',
         'name' => 'Parameter count',

--- a/data/metrics/method.php
+++ b/data/metrics/method.php
@@ -63,4 +63,5 @@ return [
             \PhpCodeArch\Metrics\MetricCollectionTypeEnum::MethodCollection,
         ],
     ],
+    ['key' => 'docBlockSummary', 'type' => 'storage'],
 ];

--- a/src/Analysis/DocumentationCoverageVisitor.php
+++ b/src/Analysis/DocumentationCoverageVisitor.php
@@ -51,21 +51,38 @@ class DocumentationCoverageVisitor implements NodeVisitor, VisitorInterface
                 $this->currentClassName[] = $className;
                 $this->classDocumented[$className] = 0;
                 $this->classTotal[$className] = 0;
+
+                $this->metricsController->setMetricValue(
+                    MetricCollectionTypeEnum::ClassCollection,
+                    ['path' => $this->path, 'name' => $className],
+                    $this->extractDocBlockSummary($node),
+                    MetricKey::DOC_BLOCK_SUMMARY
+                );
                 break;
 
             case $node instanceof Node\Stmt\ClassMethod:
-                // Only count public methods for documentation coverage
+                $name = (string) $node->name;
+                $className = end($this->currentClassName);
+
+                // Store docblock summary for ALL methods (including private/magic)
+                if (false !== $className) {
+                    $this->metricsController->setMetricValue(
+                        MetricCollectionTypeEnum::MethodCollection,
+                        ['path' => $className, 'name' => $name],
+                        $this->extractDocBlockSummary($node),
+                        MetricKey::DOC_BLOCK_SUMMARY
+                    );
+                }
+
+                // Only count public non-magic methods for documentation coverage
                 if (!$node->isPublic()) {
                     break;
                 }
 
-                // Skip magic methods
-                $name = (string) $node->name;
                 if (str_starts_with($name, '__')) {
                     break;
                 }
 
-                $className = end($this->currentClassName);
                 if (false === $className) {
                     break;
                 }
@@ -93,6 +110,13 @@ class DocumentationCoverageVisitor implements NodeVisitor, VisitorInterface
 
             case $node instanceof Node\Stmt\Function_:
                 $functionName = (string) $node->namespacedName;
+
+                $this->metricsController->setMetricValue(
+                    MetricCollectionTypeEnum::FunctionCollection,
+                    ['path' => $this->path, 'name' => $functionName],
+                    $this->extractDocBlockSummary($node),
+                    MetricKey::DOC_BLOCK_SUMMARY
+                );
 
                 ++$this->fileTotal;
 
@@ -162,6 +186,30 @@ class DocumentationCoverageVisitor implements NodeVisitor, VisitorInterface
         );
 
         return null;
+    }
+
+    private function extractDocBlockSummary(Node $node): string
+    {
+        $docComment = $node->getDocComment();
+        if (!$docComment instanceof \PhpParser\Comment\Doc) {
+            return '';
+        }
+
+        $text = $docComment->getText();
+        $text = str_replace('*/', '', $text);
+        // Use ` ?` instead of `\s?` to avoid consuming newlines (preserve paragraph breaks)
+        $text = (string) preg_replace('/^\s*\* ?/m', '', $text);
+
+        // Remove @-tags at line start (not mid-line, to preserve emails)
+        $text = (string) preg_replace('/^\s*@.*/m', '', $text);
+
+        // Remove opening comment marker
+        $text = (string) preg_replace('/^\/\*\* ?/m', '', $text);
+
+        // Collapse 3+ newlines to double newline
+        $text = (string) preg_replace('/\n{3,}/', "\n\n", $text);
+
+        return trim($text);
     }
 
     private function hasDocBlock(Node $node): bool

--- a/src/Metrics/MetricKey.php
+++ b/src/Metrics/MetricKey.php
@@ -137,6 +137,7 @@ final class MetricKey
 
     // --- Documentation & Type Coverage ---
     public const HAS_DOC_BLOCK = 'hasDocBlock';
+    public const DOC_BLOCK_SUMMARY = 'docBlockSummary';
     public const DOC_COVERAGE = 'docCoverage';
     public const DOC_PARAM_COVERAGE = 'docParamCoverage';
     public const TYPE_COVERAGE = 'typeCoverage';

--- a/templates/html/single-class.html.twig
+++ b/templates/html/single-class.html.twig
@@ -40,6 +40,13 @@
     {% endif %}
   </h2>
 
+  {% set docBlockSummary = class.get('docBlockSummary').getValue() %}
+  {% if docBlockSummary %}
+  <div class="mt-6 rounded-xl border border-white/10 bg-white/5 p-4">
+    <p class="text-white/70 leading-relaxed whitespace-pre-line">{{ docBlockSummary }}</p>
+  </div>
+  {% endif %}
+
   {% set constants = class.getCollection('constants').getAsArray() %}
   <div class="mt-8 rounded-xl border border-cyan-800 bg-cyan-950/45 p-4">
     <h3 class="mb-3 text-xl font-semibold font-display">Constants</h3>

--- a/templates/html/single-function.html.twig
+++ b/templates/html/single-function.html.twig
@@ -48,6 +48,13 @@
     </span>
   </h2>
 
+  {% set docBlockSummary = function.get('docBlockSummary').getValue() %}
+  {% if docBlockSummary %}
+  <div class="mt-6 rounded-xl border border-white/10 bg-white/5 p-4">
+    <p class="text-white/70 leading-relaxed whitespace-pre-line">{{ docBlockSummary }}</p>
+  </div>
+  {% endif %}
+
   <div class="mt-8 rounded-xl border border-cyan-800 bg-cyan-950/45 p-4">
     <h3 class="mb-3 text-xl font-semibold font-display">Parameters</h3>
     {% set parameters = parameters[function.getIdentifier().__toString()] %}

--- a/tests/Feature/Analysis/DocBlockSummaryTest.php
+++ b/tests/Feature/Analysis/DocBlockSummaryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Feature\Analysis;
+
+use PhpCodeArch\Analysis\DocumentationCoverageVisitor;
+use PhpCodeArch\Analysis\IdentifyVisitor;
+use PhpCodeArch\Metrics\Model\ClassMetrics\ClassMetricsCollection;
+use PhpCodeArch\Metrics\Model\FunctionMetrics\FunctionMetricsCollection;
+
+require_once __DIR__.'/test_helpers.php';
+
+function getDocBlockVisitors(): array
+{
+    return [
+        IdentifyVisitor::class,
+        DocumentationCoverageVisitor::class,
+    ];
+}
+
+it('extracts class docblock summary', function () {
+    $testFile = __DIR__.'/testfiles/docblock-summary.php';
+    $metricsController = getMetricsForVisitors($testFile, getDocBlockVisitors());
+
+    foreach ($metricsController->getAllCollections() as $metrics) {
+        if (!$metrics instanceof ClassMetricsCollection) {
+            continue;
+        }
+
+        $name = $metrics->getString('singleName');
+        $summary = $metrics->get('docBlockSummary')->getValue();
+
+        if ('ClassWithDocBlock' === $name) {
+            // Hand-calculated: summary text before @package tag
+            expect($summary)->toBe("A service that handles user authentication.\n\nThis is the main entry point for login flows.");
+        }
+
+        if ('ClassWithoutDocBlock' === $name) {
+            expect($summary)->toBe('');
+        }
+    }
+});
+
+it('extracts method docblock summary for all visibility levels', function () {
+    $testFile = __DIR__.'/testfiles/docblock-summary.php';
+    $metricsController = getMetricsForVisitors($testFile, getDocBlockVisitors());
+
+    $methodSummaries = [];
+
+    foreach ($metricsController->getAllCollections() as $metrics) {
+        if (!$metrics instanceof FunctionMetricsCollection) {
+            continue;
+        }
+
+        if ('method' !== $metrics->get('functionType')?->getValue()) {
+            continue;
+        }
+
+        $name = $metrics->getName();
+        $summary = $metrics->get('docBlockSummary')->getValue();
+        $methodSummaries[$name] = $summary;
+    }
+
+    // Public method with summary + tags
+    expect($methodSummaries['authenticate'])->toBe("Authenticate the given user.\n\nValidates credentials against the database.");
+
+    // Public method with only tags, no summary text
+    expect($methodSummaries['validateToken'])->toBe('');
+
+    // Public method with email in summary (must NOT cut off at @)
+    expect($methodSummaries['getHelpText'])->toBe('Contact admin@example.com for access issues.');
+
+    // Private method -- must also get a summary
+    expect($methodSummaries['isSessionValid'])->toBe('Check if the session is still valid.');
+
+    // Magic method __construct -- must also get a summary
+    expect($methodSummaries['__construct'])->toBe('Create a new instance with default settings.');
+});
+
+it('extracts function docblock summary', function () {
+    $testFile = __DIR__.'/testfiles/docblock-summary.php';
+    $metricsController = getMetricsForVisitors($testFile, getDocBlockVisitors());
+
+    foreach ($metricsController->getAllCollections() as $metrics) {
+        if (!$metrics instanceof FunctionMetricsCollection) {
+            continue;
+        }
+
+        if ('function' !== $metrics->get('functionType')?->getValue()) {
+            continue;
+        }
+
+        $name = $metrics->getString('singleName');
+        $summary = $metrics->get('docBlockSummary')->getValue();
+
+        if ('helperWithDocBlock' === $name) {
+            expect($summary)->toBe("A standalone helper function.\n\nDoes something useful.");
+        }
+
+        if ('helperWithoutDocBlock' === $name) {
+            expect($summary)->toBe('');
+        }
+    }
+});

--- a/tests/Feature/Analysis/testfiles/docblock-summary.php
+++ b/tests/Feature/Analysis/testfiles/docblock-summary.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A service that handles user authentication.
+ *
+ * This is the main entry point for login flows.
+ */
+class ClassWithDocBlock
+{
+    /**
+     * Authenticate the given user.
+     *
+     * Validates credentials against the database.
+     */
+    public function authenticate(string $username, string $password): bool
+    {
+        return true;
+    }
+
+    public function validateToken(string $token): bool
+    {
+        return true;
+    }
+
+    /**
+     * Contact admin@example.com for access issues.
+     */
+    public function getHelpText(): string
+    {
+        return '';
+    }
+
+    /**
+     * Check if the session is still valid.
+     */
+    private function isSessionValid(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Create a new instance with default settings.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function __construct(private readonly array $config = [])
+    {
+    }
+}
+
+class ClassWithoutDocBlock
+{
+    public function doSomething(): void
+    {
+    }
+}
+
+/**
+ * A standalone helper function.
+ *
+ * Does something useful.
+ */
+function helperWithDocBlock(int $value): int
+{
+    return $value;
+}
+
+function helperWithoutDocBlock(): void
+{
+}


### PR DESCRIPTION
## Summary

- Parse and display PHPDoc summary text in HTML report detail views for classes, methods, and functions
- Summaries are extracted from docblocks (text before `@`-tags) and shown only when present (no empty boxes)
- Works for all visibility levels including private methods and magic methods (`__construct`)
- Email addresses in docblock text are preserved (regex matches `@`-tags at line start only)

Closes #16

## Test plan

- [x] `composer test` — 823 tests, 1666 assertions (3 new tests)
- [x] `composer analyse` — PHPStan 0 errors
- [x] `composer cs-fix` — clean
- [x] Manual test: report on `src/`, verified `TarjanSccAlgorithm` shows class docblock summary
- [x] Manual test: methods without summary text show no empty box

🤖 Generated with [Claude Code](https://claude.com/claude-code)